### PR TITLE
feat(meilisearch-kubernetes) Add ServiceAccount'

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.0
+version: 0.1.1
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/templates/servicaccount.yaml
+++ b/charts/meilisearch/templates/servicaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "meilisearch.fullname" . }}

--- a/charts/meilisearch/templates/servicaccount.yaml
+++ b/charts/meilisearch/templates/servicaccount.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "meilisearch.fullname" . }}

--- a/charts/meilisearch/templates/serviceaccount.yaml
+++ b/charts/meilisearch/templates/serviceaccount.yaml
@@ -2,3 +2,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "meilisearch.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "meilisearch.name" . }}
+    helm.sh/chart: {{ include "meilisearch.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/charts/meilisearch/templates/serviceaccount.yaml
+++ b/charts/meilisearch/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "meilisearch.fullname" . }}

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/name: {{ include "meilisearch.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: {{ template "meilisearch.fullname" . }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}


### PR DESCRIPTION
Add a ServiceAccount to the Application.
It allows us to identify meilisearch by it's service account token. Otherwise it will be assigned the default service account. This identity is also used by service meshes and vault for example. It is generally considered best practice to add a service account to all deployed services.