### PR TITLE
Add manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,58 @@
 
 Kubernetes (K8s), is an open-source system for automating deployment, scaling, and management of containerized applications. You can run a MeiliSearch instance inside your Kubernetes cluster, either if you want to expose it to the outside world or just let some other applications use it inside your cluster and take advantage of the instant and powerful search engine.
 
-This repository's goal is to collect tools and examples of Kubernetes configurations and packages (Manifests, Helm charts, etc...) in order to make it simple to integrate a MeiliSearch instance in a Kubernetes cluster.
+# Getting started
 
-## HELM
+First of all, you will need a Kubernetes cluster up and running. If you are not familiar with how Kuberentes works or need some help with this step, please check the [Kubernetes documentation](https://kubernetes.io/docs/home/).
 
-Helm works as a package manager to run pre-configured Kubernetes resources. Using our [Helm chart](https://github.com/meilisearch/meilisearch-kubernetes/tree/master/charts/meilisearch) you will be able to deploy a MeiliSearch instance in you Kubernetes cluster, with several customizable configurations. If you want some guides on how to use it, check our [Helm chart Getting started](https://github.com/meilisearch/meilisearch-kubernetes/blob/master/charts/meilisearch/README.md#getting-started). 
+## Install kubectl
+
+`kubectl` is the most commonly used CLI to handle a Kubernetes cluster. The installation instructions are [available here](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+
+## Deploy MeiliSearch using manifests
+
+### Install and run MeiliSearch
+
+```bash
+kubectl apply -f manifests/meilisearch.yaml
+```
+
+### Uninstall MeiliSearch
+
+```bash
+kubectl delete -f manifests/meilisearch.yaml
+```
+
+## Deploy MeiliSearch using Helm
+
+Helm works as a package manager to run pre-configured Kubernetes resources. Using our [Helm chart](https://github.com/meilisearch/meilisearch-kubernetes/tree/master/charts/meilisearch) you will be able to deploy a MeiliSearch instance in you Kubernetes cluster, with several customizable configurations.
+
+### Install helm
+
+Helm CLI is a Command Line Interface which will automate chart management and installation on your Kubernetes cluster. To install Helm, follow the [Helm installation instructions](https://helm.sh/docs/intro/install/).
+
+The [Parameters](https://github.com/meilisearch/meilisearch-kubernetes/tree/master/charts/meilisearch#parameters) section lists the parameters that can be configured during installation.
+
+### Install MeiliSearch chart
+
+Clone this repository and install the chart
+
+```bash
+git clone https://github.com/meilisearch/meilisearch-kubernetes.git
+cd meilisearch-kubernetes
+# Replace <your-instance-name> with the name you would like to give to your service
+helm install <your-service-name> charts/meilisearch
+```
+
+### Uninstalling the Chart
+
+To uninstall/delete the MeiliSearch` deployment:
+
+```bash
+# Replace <your-instance-name> with the name of your deployed service
+helm uninstall <your-service-name>
+```
+
 
 <hr>
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ First of all, you will need a Kubernetes cluster up and running. If you are not 
 
 ## Install kubectl
 
-`kubectl` is the most commonly used CLI to handle a Kubernetes cluster. The installation instructions are [available here](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
+`kubectl` is the most commonly used CLI to manage a Kubernetes cluster. The installation instructions are [available here](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 
 ## Deploy MeiliSearch using manifests
 
@@ -80,4 +80,3 @@ helm uninstall <your-service-name>
 <hr>
 
 **MeiliSearch** provides and maintains many **SDKs and Integration tools** like this one. We want to provide everyone with an **amazing search experience for any kind of project**. If you want to contribute, make suggestions, or just know what's going on right now, visit us in the [integration-guides](https://github.com/meilisearch/integration-guides) repository.
-

--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.12.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.2
+version: 0.1.3
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: getmeili/meilisearch
-  tag: v0.13.0
+  tag: v0.14.0
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -1,0 +1,112 @@
+---
+# Source: meilisearch/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meilisearch
+  labels:
+    app.kubernetes.io/name: meilisearch
+    helm.sh/chart: meilisearch-0.1.2
+    app.kubernetes.io/instance: meilisearch
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: meilisearch/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: meilisearch-environment
+  labels:
+    app.kubernetes.io/name: meilisearch
+    helm.sh/chart: meilisearch-0.1.2
+    app.kubernetes.io/instance: meilisearch
+    app.kubernetes.io/managed-by: Helm
+data:
+  MEILI_ENV: "development"
+  MEILI_NO_ANALYTICS: "true"
+---
+# Source: meilisearch/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: meilisearch
+  labels:
+    app.kubernetes.io/name: meilisearch
+    helm.sh/chart: meilisearch-0.1.2
+    app.kubernetes.io/instance: meilisearch
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 7700
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: meilisearch
+    app.kubernetes.io/instance: meilisearch
+---
+# Source: meilisearch/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: meilisearch
+  labels:
+    app.kubernetes.io/name: meilisearch
+    helm.sh/chart: meilisearch-0.1.2
+    app.kubernetes.io/instance: meilisearch
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  serviceName: meilisearch
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: meilisearch
+      app.kubernetes.io/instance: meilisearch
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: meilisearch
+        app.kubernetes.io/instance: meilisearch
+    spec:
+      serviceAccountName: meilisearch
+      containers:
+        - name: meilisearch
+          image: "getmeili/meilisearch:v0.13.0"
+          imagePullPolicy: IfNotPresent
+          envFrom:
+          - configMapRef:
+              name: meilisearch-environment
+          ports:
+            - name: http
+              containerPort: 7700
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {}
+---
+# Source: meilisearch/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: meilisearch-test-connection
+  labels:
+    app.kubernetes.io/name: meilisearch
+    helm.sh/chart: meilisearch-0.1.2
+    app.kubernetes.io/instance: meilisearch
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['meilisearch:7700']
+  restartPolicy: Never

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -6,7 +6,7 @@ metadata:
   name: meilisearch
   labels:
     app.kubernetes.io/name: meilisearch
-    helm.sh/chart: meilisearch-0.1.2
+    helm.sh/chart: meilisearch-0.1.3
     app.kubernetes.io/instance: meilisearch
     app.kubernetes.io/managed-by: Helm
 ---
@@ -17,7 +17,7 @@ metadata:
   name: meilisearch-environment
   labels:
     app.kubernetes.io/name: meilisearch
-    helm.sh/chart: meilisearch-0.1.2
+    helm.sh/chart: meilisearch-0.1.3
     app.kubernetes.io/instance: meilisearch
     app.kubernetes.io/managed-by: Helm
 data:
@@ -31,7 +31,7 @@ metadata:
   name: meilisearch
   labels:
     app.kubernetes.io/name: meilisearch
-    helm.sh/chart: meilisearch-0.1.2
+    helm.sh/chart: meilisearch-0.1.3
     app.kubernetes.io/instance: meilisearch
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -52,7 +52,7 @@ metadata:
   name: meilisearch
   labels:
     app.kubernetes.io/name: meilisearch
-    helm.sh/chart: meilisearch-0.1.2
+    helm.sh/chart: meilisearch-0.1.3
     app.kubernetes.io/instance: meilisearch
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: meilisearch
       containers:
         - name: meilisearch
-          image: "getmeili/meilisearch:v0.13.0"
+          image: "getmeili/meilisearch:v0.14.0"
           imagePullPolicy: IfNotPresent
           envFrom:
           - configMapRef:
@@ -98,7 +98,7 @@ metadata:
   name: meilisearch-test-connection
   labels:
     app.kubernetes.io/name: meilisearch
-    helm.sh/chart: meilisearch-0.1.2
+    helm.sh/chart: meilisearch-0.1.3
     app.kubernetes.io/instance: meilisearch
     app.kubernetes.io/managed-by: Helm
   annotations:


### PR DESCRIPTION
Manifests are generated by Helm. To generate manifests, run `helm template meilisearch charts/meilisearch > manifests/meilisearch.yaml` at the root folder.

Added a `getting started` section in the root README.md to deploy MeiliSearch using either manifests or Helm chart.