### PR TITLE
fix(statefulset): Use healt endpoint for readiness and liveness Probe

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.17.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.6
+version: 0.1.7
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -49,11 +49,11 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /health
               port: http
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
Like discussed in #27 the readiness and liveness Probe are not working in production in version 0.17.0, because the frontend is disabled.
By calling the health endpoint, which gives us a `204 No Content` this will work

@eskombro , be my guest ;) 