### PR TITLE
Delete condition on Helm chart test in CI

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -37,8 +37,6 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0-alpha.3
-        # Only build a kind cluster if there are chart changes to test.
-        if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
         uses: helm/chart-testing-action@v1.0.0

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -43,3 +43,4 @@ jobs:
         with:
           command: install
           config: ct.yaml
+        


### PR DESCRIPTION
Runs the whole test set every time the CI is triggered, even if there is no change to the Charts. These tasks take less than 3 minutes and let us keep maintaining a safer repo.