### PR TITLE
Set target-branch to main on chart-testing-action

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -2,3 +2,4 @@ remote: origin
 chart-dirs:
   - charts
 helm-extra-args: --timeout 600s
+target-branch: main


### PR DESCRIPTION
After #51 and changing `master` to `main`, tests are failing. This PR sets the target branch of the `chart-testing-action` to `main` in the `ct.yaml` file