### PR TITLE
Increase default health check delay values: InitialDelaySeconds for readinessProbe and livenessProbe

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.19.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.11
+version: 0.1.12
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -5,12 +5,12 @@
 replicaCount: 1
 
 readinessProbe:
-  periodSeconds: 10
-  InitialDelaySeconds: 0
+  periodSeconds: 60
+  InitialDelaySeconds: 60
 
 livenessProbe:
-  periodSeconds: 10
-  InitialDelaySeconds: 0
+  periodSeconds: 60
+  InitialDelaySeconds: 60
 
 image:
   repository: getmeili/meilisearch


### PR DESCRIPTION
By default, the values of `InitialDelaySeconds` for `readinessProbe` and `livenessProbe` were set to 0. `periodSeconds` was set to 10.

1. This means that the health checks are done as soon as the container starts running. If adding this health check is best practice, it is also good to let some time for the application to start running properly before doing the health check, since a bad response can be read by kubernetess cluster as a failure and it will restart the container.
2. A period of 10 seconds between every health check seems too short for most use-cases. A check every minute seems more appropriate as a default.

These values are of course modifiable on the `values.yaml` file, but having more appropriate values seem better for most use-cases and for users who are not tuning these parameters.