### PR TITLE
Add workflow to release chart and expose via GitHub Pages

### DIFF
--- a/.github/workflows/release-chart.yaml
+++ b/.github/workflows/release-chart.yaml
@@ -1,0 +1,24 @@
+name: Release Chart
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  helm-release-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This workflow makes use of the [helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) which will automatically create a git tag whenever the the chart `version` changes.  

This will cause a release to be deployed under your [releases](https://github.com/meilisearch/meilisearch-kubernetes/releases) with a referenced `tgz` of the chart ([example](https://github.com/carlreid/meilisearch-kubernetes/releases/tag/meilisearch-0.1.12)). After that, the action will create/update and index.yaml on the `gh-pages` branch ([example](https://github.com/carlreid/meilisearch-kubernetes/tree/gh-pages)) and allow people to use `helm repo add meilisearch https://meilisearch.github.io/meilisearch-kubernetes`

**Note:**
You'll want to create a `gh-pages` branch first before merging this. You can create an empty branch like this:  
`git checkout --orphan gh-pages`
`git rm -rf .`

I also created an `index.md` ([example](https://github.com/carlreid/meilisearch-kubernetes/blob/gh-pages/index.md)) which you could use to add some instructions. Here's [what it could like](https://carlreid.github.io/meilisearch-kubernetes/).

Once you push the new branch, then modify the repo settings to be like:
![image](https://user-images.githubusercontent.com/33623601/111165354-3925b980-859f-11eb-9a59-7bec9f5aa9d0.png)

Then all should be good 🙈 

Resolves #13