### PR TITLE
Add podAnnotations and expose some static values in values.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,15 @@ The [Parameters](https://github.com/meilisearch/meilisearch-kubernetes/tree/main
 
 ### Install MeiliSearch chart
 
-Clone this repository and install the chart
-
+First, add the meilisearch chart repository  
 ```bash
-git clone https://github.com/meilisearch/meilisearch-kubernetes.git
-cd meilisearch-kubernetes
+helm repo add meilisearch https://meilisearch.github.io/meilisearch-kubernetes
+```
+
+Now install/upgrade the chart  
+```bash
 # Replace <your-instance-name> with the name you would like to give to your service
-helm install <your-service-name> charts/meilisearch
+helm upgrade -i <your-service-name> meilisearch/meilisearch
 ```
 
 ### Uninstalling the Chart

--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.19.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.12
+version: 0.1.13
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "meilisearch.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       serviceAccountName: {{ template "meilisearch.fullname" . }}
       {{- if .Values.image.pullSecret }}

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       {{- if .Values.persistence.enabled }}
       volumes:
-        - name: data
+        - name: {{ .Values.persistence.volume.name }}
           persistentVolumeClaim:
             claimName: {{ include "meilisearch.fullname" . }}
       {{- end }}
@@ -41,15 +41,15 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.persistence.enabled }}
           volumeMounts:
-            - name: data
-              mountPath: /data.ms
+            - name: {{ .Values.persistence.volume.name }}
+              mountPath: {{ .Values.persistence.volume.mountPath }}
           {{- end }}
           envFrom:
           - configMapRef:
               name: {{ template "meilisearch.fullname" . }}-environment
           ports:
             - name: http
-              containerPort: 7700
+              containerPort: {{ .Values.container.containerPort }}
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -25,6 +25,8 @@ environment:
   MEILI_NO_ANALYTICS: true
   MEILI_ENV: development
 
+podAnnotations: {}
+
 service:
   type: ClusterIP
   port: 7700

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -31,6 +31,9 @@ service:
   type: ClusterIP
   port: 7700
 
+container:
+  containerPort: 7700
+
 ingress:
   enabled: false
   annotations: {}
@@ -55,6 +58,9 @@ persistence:
   ##
   # storageClass: "-"
   size: 10Gi
+  volume:
+    name: data
+    mountPath: /data.ms
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
We need a way to annotate our pods for integration with other services, so this just adds support for that. Since I was updating these values, I thought I would also map some of those static values from the issue #53.

Resolves: #53