### PR TITLE
Update manifest on push to main

### DIFF
--- a/.github/workflows/sync-chart-manifest.yaml
+++ b/.github/workflows/sync-chart-manifest.yaml
@@ -1,0 +1,27 @@
+name: Sync chart manifest
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync_chart_manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run helm template
+        id: helm_template
+        run: |
+          helm template meilisearch charts/meilisearch | grep -v 'helm.sh/chart:\|app.kubernetes.io/managed-by:' > manifests/meilisearch.yaml
+          echo "::set-output name=has_changes::$(if git diff --quiet && git diff --quiet --cached; then echo "false"; else echo "true"; fi)"
+
+      - name: Commit manifest changes
+        if: steps.helm_template.outputs.has_changes == 'true'
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add .
+          git commit -m "[CI] Syncing Helm manifest"
+          git push --set-upstream origin main


### PR DESCRIPTION
This simply executes the `helm template` command and then performs a diff with git to see if there were any changes. If there are changes, then it will create a commit with those changes with the message `[CI] Syncing Helm manifest`.

I did initially have this run on a PR trigger, but it's very annoying if you have made changes to the chart since then you'd need to pull those changes down. Then if you were to follow up with more changes to the chart, it would result in another automated commit. Probably would add quite some noise to the commit history of `[CI] Syncing Helm manifest` 😄 

> The only "problem" I have found with this approach, is that a lot of tags are added to the manifests that are completely unnecessary and pollute them  

In response to this, I assume this is in relation to `helm.sh/chart` and `app.kubernetes.io/managed-by`. I'd disagree that they're unnecessary as the `app.kubernetes.io/managed-by` is a [recommended label](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) and so is the `helm.sh/chart` as stated [here](https://helm.sh/docs/chart_best_practices/labels/#standard-labels). So I think it's a good thing that they're being included? Maybe there's good reasons you guys don't want them in though?

[Example run of the action](https://github.com/carlreid/meilisearch-kubernetes/runs/2160300551?check_suite_focus=true).
[Example of the automated commit](https://github.com/carlreid/meilisearch-kubernetes/commit/8cab5c530dcaafce3d6790a6adf6b07737bd5d5c) (can also check the [commit history](https://github.com/carlreid/meilisearch-kubernetes/commits/main))
Resolves: #12