### PR TITLE
Generate secret for master key if the env is set to production

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v2.0.1
         with:
           command: lint
           config: ct.yaml
@@ -35,10 +35,10 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+        uses: helm/kind-action@v1.1.0
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0
+        uses: helm/chart-testing-action@v2.0.1
         with:
           command: install
           config: ct.yaml

--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.19.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.13
+version: 0.1.14
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -94,4 +94,4 @@ helm uninstall <your-service-name>
 
 The `environment` block allows to specify all the environment variables declared on [MeiliSearch Configuration](https://docs.meilisearch.com/guides/advanced_guides/configuration.html#passing-arguments-via-the-command-line)
 
-For production deployment, the `environment.MEILI_MASTER_KEY` is required
+For production deployment, the `environment.MEILI_MASTER_KEY` is required. If `MEILI_ENV` is set to "production" without setting `environment.MEILI_MASTER_KEY`, then this chart will automatically create a secure `environment.MEILI_MASTER_KEY` as a secret. To get the value of this secret, you can read it with this command: `kubectl get secret meilisearch-master-key --template={{.data.MEILI_MASTER_KEY}} | base64 --decode`.

--- a/charts/meilisearch/templates/_helpers.tpl
+++ b/charts/meilisearch/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "meilisearch.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Checks for environment being set to "production" without a master key being set explicitly
+*/}}
+{{- define "isProductionWithoutMasterKey" -}}
+{{- if and (eq .Values.environment.MEILI_ENV "production") (not .Values.environment.MEILI_MASTER_KEY) -}}
+{{- "true" -}}
+{{- else -}}
+{{- "false" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/meilisearch/templates/master-key-secret.yaml
+++ b/charts/meilisearch/templates/master-key-secret.yaml
@@ -5,6 +5,11 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $secretName }}
+  labels:
+    app.kubernetes.io/name: {{ include "meilisearch.name" . }}
+    helm.sh/chart: {{ include "meilisearch.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   {{- if $secret }}
   MEILI_MASTER_KEY: {{ $secret.data.MEILI_MASTER_KEY }} 

--- a/charts/meilisearch/templates/master-key-secret.yaml
+++ b/charts/meilisearch/templates/master-key-secret.yaml
@@ -1,0 +1,14 @@
+{{- if eq (include "isProductionWithoutMasterKey" .) "true" }}
+{{- $secretName := printf "%s-%s" (include "meilisearch.fullname" . ) "master-key" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+data:
+  {{- if $secret }}
+  MEILI_MASTER_KEY: {{ $secret.data.MEILI_MASTER_KEY }} 
+  {{ else }}
+  MEILI_MASTER_KEY: {{ randAlphaNum 20 | b64enc }}
+  {{- end }}
+{{ end }}

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -47,6 +47,10 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ template "meilisearch.fullname" . }}-environment
+          {{- if eq (include "isProductionWithoutMasterKey" .) "true" }}
+          - secretRef:
+              name: {{ template "meilisearch.fullname" . }}-master-key
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.container.containerPort }}

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -24,6 +24,11 @@ fullnameOverride: ""
 environment:
   MEILI_NO_ANALYTICS: true
   MEILI_ENV: development
+  # For production deployment, the environment MEILI_MASTER_KEY is required.
+  # If MEILI_ENV is set to "production" without setting MEILI_MASTER_KEY, this
+  # chart will automatically create a secure MEILI_MASTER_KEY and push it as a
+  # secret. Otherwise the below value of MEILI_MASTER_KEY will be used instead.
+  # MEILI_MASTER_KEY: 
 
 podAnnotations: {}
 


### PR DESCRIPTION
With these changes, if someone were to set `MEILI_ENV` to `production` and not set `MEILI_MASTER_KEY`, then a cryptographically secure random secret (using `randAlphaNum`) will be created automatically and then loaded as an environment variable.

If you set `MEILI_MASTER_KEY` in the values.yaml, then that is used instead, so no secret is generated/used.
If the env is `development` then no secret is created at all. You could still set `MEILI_MASTER_KEY` in the values.yaml, as those just get loaded in no matter what.

Resolves #19 and maybe #38