### PR TITLE
Check for out of sync manifest and add support for generating it automatically via a comment

### DIFF
--- a/.github/workflows/chart-manifest.yaml
+++ b/.github/workflows/chart-manifest.yaml
@@ -1,0 +1,73 @@
+name: Chart manifest
+on:
+  pull_request:
+    branches:
+      - main
+  issue_comment:
+    types: [created, edited]
+
+jobs:
+  check_chart_manifest_in_sync:
+    if: github.event_name == 'pull_request'
+    name: Check chart manifest is in sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check helm template in sync
+        id: helm_template
+        run: |
+          helm template meilisearch charts/meilisearch | grep -v 'helm.sh/chart:\|app.kubernetes.io/managed-by:' > manifests/meilisearch.yaml
+          if git diff --quiet && git diff --quiet --cached; then 
+            echo "✅ Manifests are in sync"; 
+          else 
+            echo "❌ Manifest update required. Comment on your PR with '@meilisearch sync-manifest' to update the manifest";
+            exit 1
+          fi
+
+  sync_chart_manifest_on_comment:
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@meilisearch sync-manifest')
+    name: Sync chart manifest
+    runs-on: ubuntu-latest
+    steps:
+      # There isn't enough detail in the github.event on "issue_comment" events about the PR origin, so we need to fetch more
+      - name: "Get Pull Request"
+        uses: actions/github-script@v3
+        id: get-pr
+        with:
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            }
+            core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+            try {
+              const result = await github.pulls.get(request)
+              return result.data
+            } catch (err) {
+              core.setFailed(`Request failed with error ${err}`)
+            }
+
+      # Now checkout the PR, generate the template and then commit to the PR
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+          ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
+
+      - name: Run helm template
+        id: helm_template
+        run: |
+          helm template meilisearch charts/meilisearch | grep -v 'helm.sh/chart:\|app.kubernetes.io/managed-by:' > manifests/meilisearch.yaml
+          echo "::set-output name=has_changes::$(if git diff --quiet && git diff --quiet --cached; then echo "false"; else echo "true"; fi)"
+
+      - name: Commit manifest changes
+        if: steps.helm_template.outputs.has_changes == 'true'
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add .
+          git commit -m "[CI] Syncing Helm manifest"
+          git push --set-upstream origin ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}

--- a/.github/workflows/check-chart-manifest.yaml
+++ b/.github/workflows/check-chart-manifest.yaml
@@ -1,0 +1,24 @@
+name: Manifest
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check_chart_manifest_in_sync:
+    name: Check in sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Check helm template in sync
+        id: helm_template
+        run: |
+          helm template meilisearch charts/meilisearch | grep -v 'helm.sh/chart:\|app.kubernetes.io/managed-by:' > manifests/meilisearch.yaml
+          if git diff --quiet && git diff --quiet --cached; then 
+            echo "✅ Manifests are in sync"; 
+          else 
+            echo "❌ Manifest update required. Comment on your PR with '@meilisearch sync-manifest' to update the manifest";
+            exit 1
+          fi

--- a/.github/workflows/update-chart-manifest.yaml
+++ b/.github/workflows/update-chart-manifest.yaml
@@ -1,34 +1,12 @@
-name: Chart manifest
+name: Manifest
 on:
-  pull_request:
-    branches:
-      - main
   issue_comment:
     types: [created, edited]
 
 jobs:
-  check_chart_manifest_in_sync:
-    if: github.event_name == 'pull_request'
-    name: Check chart manifest is in sync
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Check helm template in sync
-        id: helm_template
-        run: |
-          helm template meilisearch charts/meilisearch | grep -v 'helm.sh/chart:\|app.kubernetes.io/managed-by:' > manifests/meilisearch.yaml
-          if git diff --quiet && git diff --quiet --cached; then 
-            echo "✅ Manifests are in sync"; 
-          else 
-            echo "❌ Manifest update required. Comment on your PR with '@meilisearch sync-manifest' to update the manifest";
-            exit 1
-          fi
-
   sync_chart_manifest_on_comment:
-    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@meilisearch sync-manifest')
-    name: Sync chart manifest
+    if: contains(github.event.comment.body, '@meilisearch sync-manifest')
+    name: Sync chart manifest on comment
     runs-on: ubuntu-latest
     steps:
       # There isn't enough detail in the github.event on "issue_comment" events about the PR origin, so we need to fetch more


### PR DESCRIPTION
Attempting to tackle the manifest generation a little differently than before due to [this](https://github.com/meilisearch/meilisearch-kubernetes/pull/61#issuecomment-806152097).

To get what I think is the best middle ground, I've now made it so there's simply a check to see if the manifest is out of date, then fail if it is. When investigating, you will see the following message:
> ❌ Manifest update required. Comment on your PR with '@meilisearch sync-manifest' to update the manifest

As it says, comment on the PR with `@meilisearch sync-manifest` will then perform the job of updating the manifest and then adding a new commit to the pending PR. That way, we don't need to commit directly to `main` (due to branch protection) and then don't automatically commit to the working changes on PR (causing annoyance of rebasing/pulling for the creator).

I'm not sure if the `@meilisearch sync-manifest` is the best comment to use to trigger the job, so feel free to amend that to whatever you'd like 👍 

Since the manifest is out of date, you should see the fail check already below. Feel free to comment with `@meilisearch sync-manifest` and see if it updates the PR and resolves the fail. I think it _should_ work 🙈 Though maybe this change needs to be accepted first, before the job triggers.

Resolves: #12