### PR TITLE
Add custom labels

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.22.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.16
+version: 0.1.17
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/templates/configmap.yaml
+++ b/charts/meilisearch/templates/configmap.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "meilisearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   {{- range $key, $value := .Values.environment }}
   {{ $key }}: {{ $value | quote}}

--- a/charts/meilisearch/templates/ingress.yaml
+++ b/charts/meilisearch/templates/ingress.yaml
@@ -10,6 +10,9 @@ metadata:
     helm.sh/chart: {{ include "meilisearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/charts/meilisearch/templates/master-key-secret.yaml
+++ b/charts/meilisearch/templates/master-key-secret.yaml
@@ -10,6 +10,9 @@ metadata:
     helm.sh/chart: {{ include "meilisearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   {{- if $secret }}
   MEILI_MASTER_KEY: {{ $secret.data.MEILI_MASTER_KEY }} 

--- a/charts/meilisearch/templates/pvc.yaml
+++ b/charts/meilisearch/templates/pvc.yaml
@@ -8,6 +8,9 @@ metadata:
     helm.sh/chart: {{ include "meilisearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/charts/meilisearch/templates/service.yaml
+++ b/charts/meilisearch/templates/service.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "meilisearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/meilisearch/templates/serviceaccount.yaml
+++ b/charts/meilisearch/templates/serviceaccount.yaml
@@ -7,3 +7,6 @@ metadata:
     helm.sh/chart: {{ include "meilisearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -7,6 +7,9 @@ metadata:
     helm.sh/chart: {{ include "meilisearch.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ template "meilisearch.fullname" . }}
@@ -19,6 +22,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "meilisearch.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- with .Values.customLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     {{- with .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -32,6 +32,8 @@ environment:
 
 podAnnotations: {}
 
+customLabels: {}
+
 service:
   type: ClusterIP
   port: 7700


### PR DESCRIPTION
Added a `customLabel` attribute to `values.yaml` so that the user can costumize labels. This attribute is replicated on all templates `metadata.labels`.