### PR TITLE
Allow an existing secret to be used

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.24.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.21
+version: 0.1.22
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -31,7 +31,7 @@ This command deploys MeiliSearch on your Kubernetes cluster using the default co
 
 ## Uninstalling the Chart
 
-To uninstall/delete the MeiliSearch` deployment:
+To uninstall/delete the MeiliSearch deployment:
 
 ```bash
 # Replace <your-instance-name> with the name of your deployed service
@@ -51,6 +51,8 @@ helm uninstall <your-service-name>
 | `environment.MEILI_ENV`          | Sets the environment. Either **production** or **development** | `development`
 | | |
 | `environment.MEILI_NO_ANALYTICS` | Deactivates analytics                                          | `true`
+| | |
+| `auth.existingMasterKeySecret`   | Uses an existing secret that has the MEILI_MASTER_KEY set       | `nil`
 | | |
 | `image.repository`               | MeiliSearch image name                                         | `getmeili/meilisearch`
 | | |
@@ -100,4 +102,4 @@ helm uninstall <your-service-name>
 
 The `environment` block allows to specify all the environment variables declared on [MeiliSearch Configuration](https://docs.meilisearch.com/guides/advanced_guides/configuration.html#passing-arguments-via-the-command-line)
 
-For production deployment, the `environment.MEILI_MASTER_KEY` is required. If `MEILI_ENV` is set to "production" without setting `environment.MEILI_MASTER_KEY`, then this chart will automatically create a secure `environment.MEILI_MASTER_KEY` as a secret. To get the value of this secret, you can read it with this command: `kubectl get secret meilisearch-master-key --template={{.data.MEILI_MASTER_KEY}} | base64 --decode`.
+For production deployment, the `environment.MEILI_MASTER_KEY` is required. If `MEILI_ENV` is set to "production" without setting `environment.MEILI_MASTER_KEY`, then this chart will automatically create a secure `environment.MEILI_MASTER_KEY` as a secret. To get the value of this secret, you can read it with this command: `kubectl get secret meilisearch-master-key --template={{.data.MEILI_MASTER_KEY}} | base64 --decode`. You can also use `auth.existingMasterKeySecret` to use an existing secret that has the key `MEILI_MASTER_KEY`

--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -31,7 +31,7 @@ This command deploys MeiliSearch on your Kubernetes cluster using the default co
 
 ## Uninstalling the Chart
 
-To uninstall/delete the MeiliSearch deployment:
+To uninstall/delete the `MeiliSearch` deployment:
 
 ```bash
 # Replace <your-instance-name> with the name of your deployed service

--- a/charts/meilisearch/templates/_helpers.tpl
+++ b/charts/meilisearch/templates/_helpers.tpl
@@ -35,9 +35,17 @@ Create chart name and version as used by the chart label.
 Checks for environment being set to "production" without a master key being set explicitly
 */}}
 {{- define "isProductionWithoutMasterKey" -}}
-{{- if and (eq .Values.environment.MEILI_ENV "production") (not .Values.environment.MEILI_MASTER_KEY) -}}
+{{- if and (eq .Values.environment.MEILI_ENV "production") (not .Values.environment.MEILI_MASTER_KEY) (not .Values.auth.existingMasterKeySecret) -}}
 {{- "true" -}}
 {{- else -}}
 {{- "false" -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "secretMasterKeyName" -}}
+    {{- if .Values.auth.existingMasterKeySecret -}}
+        {{- printf "%s" (tpl .Values.auth.existingMasterKeySecret $) -}}
+    {{- else -}}
+        {{- printf "%s-master-key" (include "meilisearch.fullname" .) -}}
+    {{- end -}}
 {{- end -}}

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -53,9 +53,9 @@ spec:
           envFrom:
           - configMapRef:
               name: {{ template "meilisearch.fullname" . }}-environment
-          {{- if eq (include "isProductionWithoutMasterKey" .) "true" }}
+          {{- if or (eq (include "isProductionWithoutMasterKey" .) "true") .Values.auth.existingMasterKeySecret }}
           - secretRef:
-              name: {{ template "meilisearch.fullname" . }}-master-key
+              name: {{ template "secretMasterKeyName" . }}
           {{- end }}
           ports:
             - name: http

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -29,6 +29,9 @@ environment:
   # chart will automatically create a secure MEILI_MASTER_KEY and push it as a
   # secret. Otherwise the below value of MEILI_MASTER_KEY will be used instead.
   # MEILI_MASTER_KEY:
+auth:
+  # Use an existing Kubernetes secret for the MEILI_MASTER_KEY
+  existingMasterKeySecret: ""
 
 serviceAccount:
   annotations: {}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Adds the functionality to specify an existing secret that has the MEILI_MASTER_KEY defined.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to MeiliSearch!
