### PR TITLE
Fix ingress does not contain a valid IngressClass

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.27.1"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.33
+version: 0.1.34
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/templates/ingress.yaml
+++ b/charts/meilisearch/templates/ingress.yaml
@@ -25,6 +25,9 @@ metadata:
   {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
+  {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+  ingressClassName: nginx
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}


### PR DESCRIPTION
Add the ingressClassName field  if the k8s version higher then 1.19-0.

See: https://kubernetes.github.io/ingress-nginx/#what-is-an-ingressclass-and-why-is-it-important-for-users-of-ingress-nginx-controller-now

# Pull Request

## What does this PR do?
Fixes #116

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
