### PR TITLE
feat: allow other ingress class than Nginx

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.27.1"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.35
+version: 0.1.36
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/templates/ingress.yaml
+++ b/charts/meilisearch/templates/ingress.yaml
@@ -25,8 +25,8 @@ metadata:
   {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1"}}
-  ingressClassName: nginx
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (.Values.ingress.className) }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -56,6 +56,7 @@ container:
 
 ingress:
   enabled: false
+  className: nginx
   annotations: {}
     # kubernetes.io/ingress.class: nginx
   path: /


### PR DESCRIPTION
# Pull Request

Hello :)

## What does this PR do?

I test the ingress recently fixed (thank you for that) but I can't use it with traefik because of the ingressClassName set as default to `nginx`.
I edited the chart to allow to dynamically change this value. :)

I set nginx as the default value but in my opinion not className should be the default value.

Anyway this improvement works for me.

Have a nice day!
