### PR TITLE
Add possibility to mount volumes and specify envFrom to inject variables

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.29.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.42
+version: 0.1.43
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -61,7 +61,7 @@ helm uninstall <your-service-name>
 | `image.pullPolicy`               | Meilisearch image pull policy                                  | `IfNotPresent`
 | | |
 | `image.pullSecret`               | Secret to authenticate against the docker registry             | '' |
-|                                  |                                                                | 
+|                                  |                                                                |
 | `serviceAccount.create`          | Should this chart create a service account                     | `true`
 |                                  |                                                                |
 | `serviceAccount.annotations`     | Additional annotations for created service account             | `{}`
@@ -101,6 +101,10 @@ helm uninstall <your-service-name>
 | `resources`                      | Resources allocation (Requests and Limits)                     | `{}`
 | | |
 | `command`                        | Pod command                                                    | `[]`
+| | |
+| `volumes`                        | Additional volumes for pod                                     | `[]`
+| | |
+| `volumeMounts`                   | Additional volumes to mount on pod                             | `[]`
 | | |
 | `tolerations`                    | Tolerations for pod assignment                                 | `[]`
 | | |

--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -54,6 +54,8 @@ helm uninstall <your-service-name>
 | | |
 | `auth.existingMasterKeySecret`   | Uses an existing secret that has the MEILI_MASTER_KEY set       | `nil`
 | | |
+| `envFrom`                        | Additional environment variables from ConfigMap or secrets      | `[]`
+| | |
 | `image.repository`               | Meilisearch image name                                         | `getmeili/meilisearch`
 | | |
 | `image.tag`                      | Meilisearch image tag                                          | `{TAG_NAME}`

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -56,6 +56,9 @@ spec:
           - secretRef:
               name: {{ template "secretMasterKeyName" . }}
           {{- end }}
+          {{- if .Values.envFrom }}
+{{ toYaml .Values.envFrom | indent 10 }}
+          {{- end }}
           {{- if ne (len .Values.command) 0 }}
           command:
 {{ toYaml .Values.command | indent 12 }}

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -24,20 +24,30 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      {{- if .Values.persistence.enabled }}
+      {{- if or .Values.persistence.enabled .Values.volumes }}
       volumes:
+        {{- if .Values.persistence.enabled }}
         - name: {{ .Values.persistence.volume.name }}
           persistentVolumeClaim:
             claimName: {{ include "meilisearch.fullname" . }}
+        {{- end }}
+        {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.persistence.enabled }}
+          {{- if or .Values.persistence.enabled .Values.volumeMounts }}
           volumeMounts:
+            {{- if .Values.persistence.enabled }}
             - name: {{ .Values.persistence.volume.name }}
               mountPath: {{ .Values.persistence.volume.mountPath }}
+            {{- end }}
+            {{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 12 }}
+            {{- end }}
           {{- end }}
           envFrom:
           - configMapRef:

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -97,6 +97,10 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+volumes: []
+
+volumeMounts: []
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -34,6 +34,8 @@ auth:
   # Use an existing Kubernetes secret for the MEILI_MASTER_KEY
   existingMasterKeySecret: ""
 
+envFrom: []
+
 serviceAccount:
   # You can use a specific pre-created service account instead of
   # the one created by this chart.


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #149

## What does this PR do?

- Add `volumes` values for additional volumes on pods
- Add `volumeMounts` values to mount them on pods
- Add `envFrom` values to specify potential secrets to inject in pods.

Feedback welcome!
I bumped the version to 0.1.43, let me know if that's not how you handle versioning.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

