### PR TITLE
replace initialDelaySeconds by a startupProbe

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.30.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.45
+version: 0.1.46
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -67,6 +67,13 @@ spec:
             - name: http
               containerPort: {{ .Values.container.containerPort }}
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            initialDelaySeconds: {{ .Values.startupProbe.InitialDelaySeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
           livenessProbe:
             httpGet:
               path: /health

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -4,13 +4,18 @@
 
 replicaCount: 1
 
+startupProbe:
+  periodSeconds: 1
+  InitialDelaySeconds: 1
+  failureThreshold: 60
+
 readinessProbe:
-  periodSeconds: 60
-  InitialDelaySeconds: 60
+  periodSeconds: 10
+  InitialDelaySeconds: 0
 
 livenessProbe:
-  periodSeconds: 60
-  InitialDelaySeconds: 60
+  periodSeconds: 10
+  InitialDelaySeconds: 0
 
 image:
   repository: getmeili/meilisearch

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -87,18 +87,25 @@ spec:
             - name: http
               containerPort: 7700
               protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 1
+            initialDelaySeconds: 1
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /health
               port: http
-            periodSeconds: 60
-            initialDelaySeconds: 60
+            periodSeconds: 10
+            initialDelaySeconds: 0
           readinessProbe:
             httpGet:
               path: /health
               port: http
-            periodSeconds: 60
-            initialDelaySeconds: 60
+            periodSeconds: 10
+            initialDelaySeconds: 0
           resources:
             {}
 ---


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes long startup delay

## What does this PR do?

Instead of waiting initialDelaySeconds=60 (by default) for the pod to be ready, add a startupProbe which cheks every periodSeconds=1 during failureThreshold=60 iterations.

## PR checklist

Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?