### PR TITLE
Document missing ingress.className value in README.md

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.0.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.1.48
+version: 0.1.49
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/charts
 maintainers:

--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -74,6 +74,8 @@ helm uninstall <your-service-name>
 | | |
 | `ingress.annotations`            | Ingress annotations                                            | `{}`
 | | |
+| `ingress.className`              | Ingress ingressClassName                                       | `nginx`
+| | |
 | `ingress.path`                   | Path within the host                                           | `/`
 | | |
 | `ingress.hosts`                  | List of hostnames                                              | `[meilisearch-example.local]`


### PR DESCRIPTION
# Pull Request

## What does this PR do?

The README.md is missing documentation of the `ingress.className` value.  If you mistakenly use an annotation like `kubernetes.io/ingress.class: nginx` you will get an error and scratch your head about how to address it.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
