### PR TITLE
Fix hard coded meilisearch-master-key ref in serviceMonitor

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.3.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.2.5
+version: 0.2.8
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:

--- a/charts/meilisearch/templates/master-key-secret.yaml
+++ b/charts/meilisearch/templates/master-key-secret.yaml
@@ -1,15 +1,14 @@
 {{- if eq (include "isProductionWithoutMasterKey" .) "true" }}
-{{- $secretName := printf "%s-%s" (include "meilisearch.fullname" . ) "master-key" }}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "secretMasterKeyName" .)) -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ template "secretMasterKeyName" . }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
 data:
   {{- if $secret }}
-  MEILI_MASTER_KEY: {{ $secret.data.MEILI_MASTER_KEY }} 
+  MEILI_MASTER_KEY: {{ $secret.data.MEILI_MASTER_KEY }}
   {{ else }}
   MEILI_MASTER_KEY: {{ randAlphaNum 20 | b64enc }}
   {{- end }}

--- a/charts/meilisearch/templates/serviceMonitor.yaml
+++ b/charts/meilisearch/templates/serviceMonitor.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- if or (.Values.environment.MEILI_MASTER_KEY) (.Values.auth.existingMasterKeySecret) (eq .Values.environment.MEILI_ENV "production") }}
       bearerTokenSecret:
-        name: meilisearch-master-key
+        name: {{ template "secretMasterKeyName" . }}
         key: MEILI_MASTER_KEY
       {{- end }}
   {{- if .Values.serviceMonitor.targetLabels }}

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,5 @@
 remote: origin
 chart-dirs:
   - charts
-helm-extra-args: --timeout 600s
+# helm-extra-args: --timeout 600s
 target-branch: main

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -75,7 +75,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: fe89006beb14ca937e98a51d6dadf00eb3a1cc0263ad03d23a531be38b4eaf15
+        checksum/config: 136a06ce32226c3ca55823dbc13dcbcea97ee3b44a9a459a0ec866a641eb92c0
     spec:
       serviceAccountName: meilisearch
       securityContext:


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Fix hard coded meilisearch-master-key ref in serviceMonitor. The serviceMonitor was broken when the helm deployment name was changed from the default `meilisearch`. This also uses the existing template for all secretMasterKeyName usages which ensures consistency.

N.B. Please also consider fixing the language used in the application and this chart. "Master" is a dated and divisive term.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
