### PR TITLE
feat: reintroduce the possibility to specify a replicaCount in values.yaml

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.3.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.2.5
+version: 0.2.6
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount | default 1 }}
   serviceName: {{ template "meilisearch.fullname" . }}
   selector:
     matchLabels:

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -75,7 +75,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: 73c3b4e0b1c0b03eddb60d433406ec9e300540938d9f5fdbb9177cbe39dc6bac
+        checksum/config: 83205b90c0b551bef66ed63fe77a0350e8293bafa30c5eb3b562848e709e6f26
     spec:
       serviceAccountName: meilisearch
       securityContext:


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Re-enable the possibility to customize the `spec.replicas` value of the StatefulSet, a requirement we have for our internal High Availability tests.
- Keep a default value of 1 replica to match the most common uses.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
