### PR TITLE
Add VPC to k8s manifest (change default to persistent - true)

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.5.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.3.0
+version: 0.4.0
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -113,7 +113,7 @@ ingress:
 
 persistence:
   # -- Enable persistence using PVC
-  enabled: false
+  enabled: true
   # -- PVC Access Mode
   accessMode: ReadWriteOnce
   ## Persistent Volume Storage Class

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -34,7 +34,7 @@ metadata:
   labels:
     app.kubernetes.io/name: meilisearch
     app.kubernetes.io/instance: meilisearch
-    app.kubernetes.io/version: "v1.4.0"
+    app.kubernetes.io/version: "v1.5.0"
     app.kubernetes.io/component: search-engine
     app.kubernetes.io/part-of: meilisearch
 spec:
@@ -94,7 +94,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: e65a5b09b17b1effcddb830c9a9bdecd1f3ce42695ebf236191c61393ab0ed32
+        checksum/config: 86a4086cc53ccd0628648b68320a381a6963524b7d68295cbdecc4cb5554238f
     spec:
       serviceAccountName: meilisearch
       securityContext:

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -26,6 +26,25 @@ data:
   MEILI_ENV: "development"
   MEILI_NO_ANALYTICS: "true"
 ---
+# Source: meilisearch/templates/pvc.yaml
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: meilisearch
+  labels:
+    app.kubernetes.io/name: meilisearch
+    app.kubernetes.io/instance: meilisearch
+    app.kubernetes.io/version: "v1.4.0"
+    app.kubernetes.io/component: search-engine
+    app.kubernetes.io/part-of: meilisearch
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "10Gi"
+  storageClassName: ""
+---
 # Source: meilisearch/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -88,7 +107,8 @@ spec:
         - name: tmp
           emptyDir: {}
         - name: data
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: meilisearch
       containers:
         - name: meilisearch
           image: "getmeili/meilisearch:v1.4.0"


### PR DESCRIPTION
# Pull Request
The plain k8s manifest (not the HELM version), does not have PVC for the kube stateful set. 
This PR adds it for the next developer who wants to grab manifest for working meilisearch without using helm. 


## Related issue
Related issue:, https://github.com/meilisearch/meilisearch-kubernetes/issues/159 

## What does this PR do?
- add's missing PVC to the k8s manifest 

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
