### PR TITLE
Add initContainer support

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.7.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.5.0
+version: 0.6.0
 icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -46,6 +46,12 @@ spec:
         {{- if .Values.volumes }}
 {{ toYaml .Values.volumes | indent 8 }}
         {{- end }}
+
+      {{ if .Values.initContainers }}
+      initContainers:
+        {{ toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
+            
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -55,7 +55,7 @@ serviceAccount:
   # -- Should this chart create a service account
   create: true
   # -- Custom service account name, if not created by this chart
-  name: ''
+  name: ""
   # -- Additional annotations for created service account
   annotations: {}
 
@@ -98,7 +98,8 @@ ingress:
   # -- Ingress ingressClassName
   className: nginx
   # -- Ingress annotations
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
   # -- Path within the host
   path: /
@@ -140,7 +141,8 @@ persistence:
     mountPath: /meili_data
 
 # -- Resources allocation (Requests and Limits)
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -160,6 +162,9 @@ volumeMounts: []
 
 # -- Additional containers for pod
 containers: []
+
+# -- Additional initContainers for pod
+initContainers: []
 
 # -- Node labels for pod assignment
 nodeSelector: {}

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -75,7 +75,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: 468906c495caf47f44d906b3f928bbf1c5ee0fd11b345f9d07cbbc6d626b8fcf
+        checksum/config: 35d680140fa9645374b032a4c6f416b2932bd677d97949691b714ece482ffa69
     spec:
       serviceAccountName: meilisearch
       securityContext:

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -89,6 +89,9 @@ spec:
           emptyDir: {}
         - name: data
           emptyDir: {}
+
+      
+            
       containers:
         - name: meilisearch
           image: "getmeili/meilisearch:v1.7.0"


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #226

## What does this PR do?
- Enables support for `initContainers` consistent with enablement for `containers` and `volumes` etc

## Example
I was able to create an `initContainer` pattern that pulled a `.dump` file from S3 and mounted it into the Meili pod using the following values:

```
initContainers:
  - name: aws-copy
    image: amazon/aws-cli
    envFrom:
      - configMapRef:
          name: env-with-s3-creds
    command:
      - "/bin/sh"
      - "-c"
      - aws s3 cp "s3://$S3_BUCKET/meilisearch_dumps" /meili_data/dumps --recursive
    volumeMounts:
      - name: meili-dumps
        mountPath: /meili_data/dumps
volumes:
  - name: meili-dumps
    emptyDir: {}
volumeMounts:
  - name: meili-dumps
    mountPath: /meili_data/dumps
environment:
  MEILI_IMPORT_DUMP: /meili_data/dumps/myClonedDumpFile.dump
  MEILI_ENV: development
  MEILI_MASTER_KEY: someReallyCoolKeyAlsoWookiesRule
  MEILI_NO_ANALYTICS: true
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [ X ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ X ] Have you read the contributing guidelines?
- [ X ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
