### PR TITLE
Replace Chart.yml icon by a well known image URL

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "v1.7.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
 version: 0.5.0
-icon: https://res.cloudinary.com/meilisearch/image/upload/v1597822872/Logo/logo_img.svg
+icon: https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/logo.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:
     - name: Bruno

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -75,7 +75,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: 35d680140fa9645374b032a4c6f416b2932bd677d97949691b714ece482ffa69
+        checksum/config: a0b986784ffc3cc8552f85f04f7d4796ae5f5773c344b6ad1827d8a9b68fde9e
     spec:
       serviceAccountName: meilisearch
       securityContext:


### PR DESCRIPTION
Just in case someone removes it :)

The new URL is under our [integration-guides repo](https://github.com/meilisearch/integration-guides/)