### PR TITLE
Update for  startupProbe, livenessProbe, readinessProbe in meilisearc…

### DIFF
--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -117,20 +117,20 @@ spec:
           startupProbe:
             httpGet:
               path: /health
-              port: http
+              port: 7700
             periodSeconds: 1
             initialDelaySeconds: 1
             failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /health
-              port: http
+              port: 7700
             periodSeconds: 10
             initialDelaySeconds: 0
           readinessProbe:
             httpGet:
               path: /health
-              port: http
+              port: 7700
             periodSeconds: 10
             initialDelaySeconds: 0
           resources:


### PR DESCRIPTION
…h.yaml

sur les startupProbe, livenessProbe, readinessProbe, j'ai du mettre :  port: 7700

sinon j'avais une erreur 
'Startup probe errored: strconv.Atoi: parsing "http": invalid syntax' et le service reste innaccessible

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
