### PR TITLE
Add namespace metadata option in templates

### DIFF
--- a/charts/meilisearch/templates/configmap.yaml
+++ b/charts/meilisearch/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "meilisearch.fullname" . }}-environment
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
 data:

--- a/charts/meilisearch/templates/ingress.yaml
+++ b/charts/meilisearch/templates/ingress.yaml
@@ -12,6 +12,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/meilisearch/templates/master-key-secret.yaml
+++ b/charts/meilisearch/templates/master-key-secret.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "secretMasterKeyName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
 data:

--- a/charts/meilisearch/templates/pvc.yaml
+++ b/charts/meilisearch/templates/pvc.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "meilisearch.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
   {{- with .Values.persistence.annotations }}

--- a/charts/meilisearch/templates/service.yaml
+++ b/charts/meilisearch/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "meilisearch.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/meilisearch/templates/serviceMonitor.yaml
+++ b/charts/meilisearch/templates/serviceMonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "meilisearch.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}

--- a/charts/meilisearch/templates/serviceaccount.yaml
+++ b/charts/meilisearch/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "meilisearch.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ include "meilisearch.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
 spec:

--- a/charts/meilisearch/templates/tests/test-connection.yaml
+++ b/charts/meilisearch/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "meilisearch.fullname" . | lower }}-test-connection
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "meilisearch.name" . }}
     helm.sh/chart: {{ include "meilisearch.chart" . }}


### PR DESCRIPTION
This sets the namespace key in metadata for all kubernetes manifests. The `.Release.Namespace` is a built-in variable in helm, that can be passed with `--namespace` on `install` or `template` step. If not set it defaults to `default`.

**Why?**

When using `helm install` with the `--namespace` argument the templates are applied into the chosen namespace.

When using helm only as a template engine, in combination with GitOps tools like Flux, the namespace property must be set in the rendered manifests to be applied. For `--namespace` to have an effect when using `helm template`, it must be present like this in the templates.

This change should not have any effect/change for `helm install` approach as far as I know.

# Pull Request

## Related issue
Possibly a fix for #230

## What does this PR do?
- Sets the namespace key in metadata for all kubernetes manifests

## PR checklist
Please check if your PR fulfills the following requirements:
- [ x ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ x ] Have you read the contributing guidelines?
- [ x ] Have you made sure that the title is accurate and descriptive of the changes?

