### PR TITLE
Support dynamic serviceMonitor Namespace

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.14.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.12.1
+version: 0.12.2
 icon: https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/logo.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:

--- a/charts/meilisearch/templates/serviceMonitor.yaml
+++ b/charts/meilisearch/templates/serviceMonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "meilisearch.fullname" . }}
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
   labels:
     {{- include "meilisearch.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.additionalLabels }}

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -185,8 +185,8 @@ command: []
 serviceMonitor:
   # -- Enable ServiceMonitor to configure scraping
   enabled: false
-  # -- Set of labels to transfer from the Kubernetes Service onto the target
-  namespace:  # @schema type:[string, null]; default: null
+  # -- Set Namespace
+  namespace: null
   # -- Set of labels to transfer from the Kubernetes Service onto the target
   additionalLabels: {}
   # -- Set scraping frequency

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -186,6 +186,8 @@ serviceMonitor:
   # -- Enable ServiceMonitor to configure scraping
   enabled: false
   # -- Set of labels to transfer from the Kubernetes Service onto the target
+  namespace:  # @schema type:[string, null]; default: null
+  # -- Set of labels to transfer from the Kubernetes Service onto the target
   additionalLabels: {}
   # -- Set scraping frequency
   interval: 1m

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -75,7 +75,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: e9b299959eea060a9071d120c09445cace56d11be3097866a65e59f89b179229
+        checksum/config: be95af245aea2dae315d177c62e9942bebacb57bcd9a2d4622045e7cdf4267e4
     spec:
       serviceAccountName: meilisearch
       securityContext:


### PR DESCRIPTION
In the default values the serviceMonitor.Namespace is available but this is not taking into account

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
