### PR TITLE
Release v0.13.0

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.14.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.12.2
+version: 0.13.0
 icon: https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/logo.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -75,7 +75,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: be95af245aea2dae315d177c62e9942bebacb57bcd9a2d4622045e7cdf4267e4
+        checksum/config: c3dee14767cb62ddcf4e19a591493440095d39ed1bf7760a24723b9215d289c3
     spec:
       serviceAccountName: meilisearch
       securityContext:


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch-kubernetes/issues/254

## What does this PR do?
I've inadvertently released the new engine v1.14.0 as v0.12.1 (patch) when it should be a minor version v0.13.0, so I'm doing it now.

This release introduces no change.
