### PR TITLE
Add automation to open a PR when a new Meilisearch release is done

### DIFF
--- a/.github/workflows/update-meilisearch-version.yaml
+++ b/.github/workflows/update-meilisearch-version.yaml
@@ -3,6 +3,13 @@ name: Update Meilisearch Version
 on:
   repository_dispatch:
     types: [meilisearch-release]
+  # For testing purposes
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Meilisearch version to test (e.g., v1.25.0)'
+        required: true
+        type: string
 
 jobs:
   update-version:


### PR DESCRIPTION
Partially closes https://linear.app/meilisearch/issue/ENGPROD-2152/open-pr-for-k8s-integration-when-a-meilisearch-release-is-done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that reacts to release events (and supports manual testing) to detect new Meilisearch versions, validate and sanitize the version, and—when needed—update chart/app versions, image tags, compatibility notes, and regenerated Kubernetes manifests.
  * When an update is required, it opens a descriptive pull request with changelog link and labels; does nothing if already up-to-date.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->