### PR TITLE
Adapt manifest for workflow dispatch

### DIFF
--- a/.github/workflows/update-meilisearch-version.yaml
+++ b/.github/workflows/update-meilisearch-version.yaml
@@ -124,7 +124,7 @@ jobs:
         with:
           token: ${{ secrets.MEILI_BOT_GH_PAT }}
           commit-message: "chore(version): bump Meilisearch to ${{ steps.version.outputs.new_version }}"
-          title: "⬆️ Bump Meilisearch to ${{ steps.version.outputs.new_version }}"
+          title: "Bump Meilisearch to ${{ steps.version.outputs.new_version }}"
           body: |
             ## Description
 
@@ -149,5 +149,6 @@ jobs:
           labels: |
             dependencies
             automated
+          reviewers: brunoocasali
           delete-branch: true
 


### PR DESCRIPTION
Close partially: https://linear.app/meilisearch/issue/ENGPROD-2152/open-pr-for-k8s-integration-when-a-meilisearch-release-is-done
Proof it works with workflow dispatch: https://github.com/meilisearch/meilisearch-kubernetes/pull/284

Official test in production next Monday for the "communication" between engine and the repo 😁

The other side: https://github.com/meilisearch/meilisearch/pull/6023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version update automation workflow to support multiple trigger methods for improved flexibility.
  * Simplified pull request title format for clearer version bump notifications.
  * Configured automated reviewer assignment for streamlined code review processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->