### PR TITLE
Fix chart test for openshift

### DIFF
--- a/charts/meilisearch/Chart.yaml
+++ b/charts/meilisearch/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v1.32.0"
 description: A Helm chart for the Meilisearch search engine
 name: meilisearch
-version: 0.21.0
+version: 0.25.1
 icon: https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/logo.svg
 home: https://github.com/meilisearch/meilisearch-kubernetes/tree/main/charts/meilisearch
 maintainers:

--- a/charts/meilisearch/templates/tests/test-connection.yaml
+++ b/charts/meilisearch/templates/tests/test-connection.yaml
@@ -14,5 +14,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "meilisearch.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['--spider', '--timeout=5', '{{ include "meilisearch.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/charts/meilisearch/templates/tests/test-connection.yaml
+++ b/charts/meilisearch/templates/tests/test-connection.yaml
@@ -14,5 +14,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['--spider', '--timeout=5', '{{ include "meilisearch.fullname" . }}:{{ .Values.service.port }}']
+      args: ['--spider', '--timeout=5', '{{ include "meilisearch.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -76,7 +76,7 @@ spec:
         app.kubernetes.io/component: search-engine
         app.kubernetes.io/part-of: meilisearch
       annotations:
-        checksum/config: 0135270fc5e0281cdcbd9d2530da37189a1ef1be9e3957163b0549fb2e3777da
+        checksum/config: 4fd7cc94794d90cd39e5cef6eaadbb94e894e99ddbf5160325dba02fd008cd3b
     spec:
       serviceAccountName: meilisearch
       securityContext:
@@ -155,5 +155,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['--spider', '--timeout=5', 'meilisearch:7700']
+      args: ['--spider', '--timeout=5', 'meilisearch:7700']
   restartPolicy: Never

--- a/manifests/meilisearch.yaml
+++ b/manifests/meilisearch.yaml
@@ -155,5 +155,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['meilisearch:7700']
+      args:  ['--spider', '--timeout=5', 'meilisearch:7700']
   restartPolicy: Never


### PR DESCRIPTION
# Pull Request

## Related issue

This charts' tests fail on OpenShift due to stronger permission requirements.

```
POD LOGS: catalog-meilisearch-test-connection
Connecting to catalog-meilisearch:7700 (172.30.6.171:7700)
wget: can't open 'index.html': Permission denied

Error: 1 error occurred:
        * pod catalog-meilisearch-test-connection failed
```

## What does this PR do?

On OpenShift, the test pod is "not allowed" to write to it's own filesystem, i.e. when wget tries to download the index of the service, the test fails (see my output above). We can use --spider to prevent wget from writing to the filesystem, and then only verifying if the service is reachable over http, which is what we want to check. Also added timeout to prevent unbounded execution time.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved readiness check reliability by switching the probe to a non-invasive "spider" style check with an explicit timeout, reducing false positives and avoiding full requests during health checks.
* **Chores**
  * Bumped chart version and updated configuration checksum to ensure configuration changes are recognized and deployments refresh appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->