### PR TITLE
Update outdated documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://discord.meilisearch.com">Discord</a> |
   <a href="https://www.meilisearch.com">Website</a> |
   <a href="https://blog.meilisearch.com">Blog</a> |
-  <a href="https://www.meilisearch.com/docs/faq">FAQ</a>
+  <a href="https://www.meilisearch.com/docs/learn/resources/faq">FAQ</a>
 </h4>
 
 <p align="center">
@@ -32,7 +32,7 @@
 
 ## 📖 Documentation
 
-See our [Documentation](https://www.meilisearch.com/docs/learn/getting_started/installation) or our [API References](https://www.meilisearch.com/docs/reference/api/overview).
+See our [Documentation](https://www.meilisearch.com/docs/learn/self_hosted/install_meilisearch_locally) or our [API References](https://www.meilisearch.com/docs/reference/api/authorization).
 
 ## ⚡ Supercharge your Meilisearch experience
 

--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -44,7 +44,7 @@ helm uninstall <your-service-name>
 
 ## Environment
 
-The `environment` block allows to specify all the environment variables declared on [Meilisearch Configuration](https://www.meilisearch.com/docs/learn/configuration/instance_options#command-line-options-and-flags)
+The `environment` block allows to specify all the environment variables declared on [Meilisearch Configuration](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#command-line-options-and-flags)
 
 For production deployment, the `environment.MEILI_MASTER_KEY` is required. If `MEILI_ENV` is set to "production" without setting `environment.MEILI_MASTER_KEY`, then this chart will automatically create a secure `environment.MEILI_MASTER_KEY` as a secret.
 

--- a/charts/meilisearch/README.md.gotmpl
+++ b/charts/meilisearch/README.md.gotmpl
@@ -43,7 +43,7 @@ helm uninstall <your-service-name>
 
 ## Environment
 
-The `environment` block allows to specify all the environment variables declared on [Meilisearch Configuration](https://www.meilisearch.com/docs/learn/configuration/instance_options#command-line-options-and-flags)
+The `environment` block allows to specify all the environment variables declared on [Meilisearch Configuration](https://www.meilisearch.com/docs/learn/self_hosted/configure_meilisearch_at_launch#command-line-options-and-flags)
 
 For production deployment, the `environment.MEILI_MASTER_KEY` is required. If `MEILI_ENV` is set to "production" without setting `environment.MEILI_MASTER_KEY`, then this chart will automatically create a secure `environment.MEILI_MASTER_KEY` as a secret. 
 


### PR DESCRIPTION
## Summary
- Updated `meilisearch.com/docs` links to match the current sitemap URLs
- Old paths were either redirecting (308) or returning 404s

## Test plan
- [ ] Verify all updated links resolve correctly (no 404s or extra redirects)
- [ ] No code logic changed — only documentation URLs