### PR TITLE
feat: make container args configurable

### DIFF
--- a/charts/meilisearch/README.md
+++ b/charts/meilisearch/README.md
@@ -57,6 +57,7 @@ You can also use `auth.existingMasterKeySecret` to use an existing secret that h
 | affinity | object | `{}` | Affinity for pod assignment |
 | auth.existingMasterKeySecret | string | `""` | Use an existing Kubernetes secret for the MEILI_MASTER_KEY |
 | command | list | `[]` | Pod command |
+| args | list | `[]` | Pod args |
 | container.containerPort | int | `7700` |  |
 | containers | list | `[]` | Additional containers for pod |
 | customLabels | object | `{}` | Additional labels to add to all resources |

--- a/charts/meilisearch/templates/statefulset.yaml
+++ b/charts/meilisearch/templates/statefulset.yaml
@@ -83,6 +83,10 @@ spec:
           command:
 {{ toYaml .Values.command | indent 12 }}
           {{- end }}
+          {{- if ne (len .Values.args) 0 }}
+          args:
+{{ toYaml .Values.args | indent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.container.containerPort }}

--- a/charts/meilisearch/values.yaml
+++ b/charts/meilisearch/values.yaml
@@ -165,6 +165,8 @@ tolerations: []
 affinity: {}
 # -- Pod command
 command: []
+# -- Pod arguments
+args: []
 # -- Monitoring with Prometheus Operator
 serviceMonitor:
   # -- Enable ServiceMonitor to configure scraping


### PR DESCRIPTION
# Pull Request

## Related issue
Potentially #159

## What does this PR do?
I want to able to customize the args that are passed to meilisearch. Specifically, I want to be able to pass the `--experimental-dumpless-upgrade` flag. In the linked issue, this is achieved via command. If I remember correctly the command + empty args overwrites the entrypoint + cmd of the containerfile defined here: https://github.com/meilisearch/meilisearch/blob/0e42f5daee12d4e8212566bca07a52e8a77697f8/Dockerfile#L45-L46

I am not sure whether/why the `tini` entrypoint is required but I want to remain compatible with the upstream docker image, hence I'd prefer to only modify the actualy args/CMD and not the command/ENTRYPOINT

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable container startup arguments in Helm chart deployments. Users can now pass command-line arguments to Meilisearch alongside existing command configuration options through chart values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->