### PR TITLE
Fix too long kubernetes labels when using digest in image tag 

### DIFF
--- a/charts/meilisearch/templates/_helpers.tpl
+++ b/charts/meilisearch/templates/_helpers.tpl
@@ -35,7 +35,9 @@ Create chart name and version as used by the chart label.
 helm.sh/chart: {{ include "meilisearch.chart" . }}
 {{ include "meilisearch.selectorLabels" . }}
 {{- if or .Chart.AppVersion .Values.image.tag }}
-app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+{{- $rawVersion := .Values.image.tag | default .Chart.AppVersion }}
+{{- $version := regexReplaceAll "@sha256:[a-f0-9]+" $rawVersion "" | trunc 63 | trimSuffix "-" }}
+app.kubernetes.io/version: {{ $version | quote }}
 {{- end }}
 app.kubernetes.io/component: search-engine
 app.kubernetes.io/part-of: {{ template "meilisearch.name" . }}


### PR DESCRIPTION
# Pull Request

## Related issue

NaN

## What does this PR do?

Labels have to be less than 63 characters, so when using a digest in the tag, which is recommended [0], the label
becomes too long and the chart fails. This change strips away any digest or pinning after the tag.

[0]: https://docs.docker.com/dhi/core-concepts/digests/

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR prevents Kubernetes label failures caused by overly long image tags (e.g., when using image digests) by adding a configurable label value and sanitizing the version used in labels.

## Changes

### New Configuration Option
- Added `image.versionLabel` to charts/meilisearch/values.yaml (defaults to empty string). Documented as intended for use when the image tag is pinned to a digest.

### Label Generation Logic Update
- Updated charts/meilisearch/templates/_helpers.tpl → `meilisearch.labels`:
  - `app.kubernetes.io/version` is now emitted only when either `.Chart.AppVersion` or `.Values.image.tag` is set.
  - The label value is computed from `.Values.image.tag` with a fallback to `.Chart.AppVersion`, then:
    - Strips any `@sha256:...` digest suffix,
    - Truncates to 63 characters,
    - Trims a trailing `-`,
    - Quotes the result.

## Design Rationale
Sanitizing and truncating the version keeps label values within Kubernetes' 63-character limit. The added `image.versionLabel` provides an opt-in configurable field for users, though the template currently derives the emitted version from `image.tag` → `Chart.AppVersion` and applies normalization to ensure label validity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->