### PR TITLE
Fix master key secret creation for ServiceMonitor compatibility

### DIFF
--- a/charts/meilisearch/templates/master-key-secret.yaml
+++ b/charts/meilisearch/templates/master-key-secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "isProductionWithoutMasterKey" .) "true" }}
+{{- if or (eq (include "isProductionWithoutMasterKey" .) "true") (and (.Values.environment.MEILI_MASTER_KEY) (not .Values.auth.existingMasterKeySecret)) }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "secretMasterKeyName" .)) -}}
 apiVersion: v1
 kind: Secret
@@ -9,6 +9,8 @@ metadata:
 data:
   {{- if $secret }}
   MEILI_MASTER_KEY: {{ $secret.data.MEILI_MASTER_KEY }}
+  {{- else if (.Values.environment.MEILI_MASTER_KEY) }}
+  MEILI_MASTER_KEY: {{ .Values.environment.MEILI_MASTER_KEY | b64enc }}
   {{ else }}
   MEILI_MASTER_KEY: {{ randAlphaNum 20 | b64enc }}
   {{- end }}


### PR DESCRIPTION
# Pull Request

## Related issue

Fixes failing ServiceMonitor when `MEILI_MASTER_KEY` is specified as the main secret.

## What does this PR do?

The service monitor *REQUIRES* the kubernetes secret to be present to be able to query for the metrics, i.e. we should make the secret also when the `MEILI_MASTER_KEY` is used to pass the main secret.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Fixed failing ServiceMonitor when MEILI_MASTER_KEY is provided via environment variables

This PR fixes a bug where the ServiceMonitor fails when the `MEILI_MASTER_KEY` is supplied through environment variables rather than an existing Kubernetes Secret. The ServiceMonitor requires a Kubernetes Secret to be present to query metrics, but the secret was not being created in this scenario.

### Changes

**charts/meilisearch/templates/master-key-secret.yaml**

The Secret creation condition has been extended to account for environment-supplied master keys:
- Broadened the template condition (line 1) to render the Secret not only when `isProductionWithoutMasterKey` is true, but also when `.Values.environment.MEILI_MASTER_KEY` is set and `.Values.auth.existingMasterKeySecret` is not provided
- Added an `else if` branch (line 12) to populate the Secret data with the value from `.Values.environment.MEILI_MASTER_KEY` before falling back to generating a random key

This ensures that the master key Secret is created whenever the ServiceMonitor needs it, allowing the ServiceMonitor to successfully authenticate and query metrics in all deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->